### PR TITLE
Add missing dependency on realsense

### DIFF
--- a/stretch_description/package.xml
+++ b/stretch_description/package.xml
@@ -59,6 +59,7 @@
 
   <depend>std_msgs</depend>
   <depend>geometry_msgs</depend>
+  <depend>realsense_ros</depend>
   <build_depend>roslaunch</build_depend>
   
   <exec_depend>robot_state_publisher</exec_depend>


### PR DESCRIPTION
Required from [here](https://github.com/hello-robot/stretch_ros/blob/88336987b1c30c58aff1c423ca33756ce308c0f4/stretch_description/urdf/stretch_d435i.xacro#L6)