### PR TITLE
Fix initialization order

### DIFF
--- a/stretch_core/nodes/stretch_driver
+++ b/stretch_core/nodes/stretch_driver
@@ -552,8 +552,6 @@ class StretchBodyNode:
         self.magnetometer_mobile_base_pub = rospy.Publisher('magnetometer_mobile_base', MagneticField, queue_size=1)
         self.imu_wrist_pub = rospy.Publisher('imu_wrist', Imu, queue_size=1)
 
-        rospy.Subscriber("cmd_vel", Twist, self.set_mobile_base_velocity_callback)
-
         # ~ symbol gets parameter from private namespace
         self.joint_state_rate = rospy.get_param('~rate', 15.0)
         self.timeout = rospy.get_param('~timeout', 1.0)
@@ -610,6 +608,8 @@ class StretchBodyNode:
         self.runstop_service = rospy.Service('/runstop',
                                               SetBool,
                                               self.runstop_service_callback)
+
+        rospy.Subscriber("cmd_vel", Twist, self.set_mobile_base_velocity_callback)
 
         try:
             # start loop to command the mobile base velocity, publish


### PR DESCRIPTION
If you start the driver, and someone is already publishing `cmd_vel` topics (e.g. running mapping.launch) then `set_mobile_base_velocity_callback` will be called before the robot is initialized, and crucially, also before [it is switched into navigation mode](https://github.com/hello-robot/stretch_ros/blob/dbd02041b12f7811e990f0e13f1dc8755b93354f/stretch_core/nodes/stretch_driver#L589). 

This results in an error being published to the screen and other deleterious effects. 
`[ERROR] [1609963416.663667]: /stretch_driver action server must be in navigation mode to receive a twist on cmd_vel. Current mode = None.`