### PR TITLE
fix diagnostic_updater arguments

### DIFF
--- a/stretch_core/nodes/stretch_diagnostics.py
+++ b/stretch_core/nodes/stretch_diagnostics.py
@@ -92,7 +92,7 @@ class StretchDiagnostics:
     def __init__(self, node, robot):
         self.node = node
         self.robot = robot
-        self.updater = diagnostic_updater.Updater(node)
+        self.updater = diagnostic_updater.Updater()
         self.updater.setHardwareID(hello_utils.get_fleet_id())
 
         # Configure the different update functions


### PR DESCRIPTION
When I ran the calibration commands using the latest tip of the `dev/noetic` branch commits that I updated today, I got errors pointing out that `Updater` now takes only one argument, not two.

A previous tip on the same branch that was ~125 commits older didn't have this error