### PR TITLE
lowering nav velocity rate to 15

### DIFF
--- a/stretch_core/launch/stretch_driver.launch
+++ b/stretch_core/launch/stretch_driver.launch
@@ -34,7 +34,7 @@
   </node>
 
   <node name="stretch_driver" pkg="stretch_core" type="stretch_driver" output="screen">
-    <param name="rate" type="double" value="25.0"/>
+    <param name="rate" type="double" value="15.0"/>
     <param name="timeout" type="double" value="0.5"/>
     <remap from="cmd_vel" to="/stretch/cmd_vel" />
     <remap from="joint_states" to="/stretch/joint_states" />


### PR DESCRIPTION
The navigation push_command rate exceeds the 20hz limit of Stretch Body. The latest Stretch Body prints periodic warnings to the console. The Joint Trajectory Server uses 15Hz. I'd propose we move to 15Hz to be consistent.