### PR TITLE
Fix yaml.load crash by specifying loader

### DIFF
--- a/stretch_calibration/nodes/collect_head_calibration_data
+++ b/stretch_calibration/nodes/collect_head_calibration_data
@@ -562,9 +562,8 @@ class CollectHeadCalibrationDataNode:
         else:
             filename = self.calibration_directory + 'head_calibration_data_' + capture_date + '.yaml'
         rospy.loginfo('Saving calibration_data to a YAML file named {0}'.format(filename))
-        fid = open(filename, 'w')
-        yaml.dump(calibration_data, fid)
-        fid.close()
+        with open (filename, 'w') as fid:
+            yaml.dump(calibration_data, fid)
         rospy.loginfo('')
         rospy.loginfo('*************************************')
         rospy.loginfo('')
@@ -609,9 +608,8 @@ class CollectHeadCalibrationDataNode:
         filename = rospy.get_param('~controller_calibration_file')
 
         rospy.loginfo('Loading factory default tilt backlash transition angle from the YAML file named {0}'.format(filename))
-        fid = open(filename, 'r')
-        controller_parameters = yaml.load(fid)
-        fid.close()
+        with open(filename, 'r') as fid:
+            controller_parameters = yaml.load(fid, Loader=yaml.FullLoader)
         self.tilt_angle_backlash_transition_rad = controller_parameters['tilt_angle_backlash_transition']
         deg_per_rad = 180.0/math.pi
         rospy.loginfo('self.tilt_angle_backlash_transition_rad in degrees = {0}'.format(self.tilt_angle_backlash_transition_rad * deg_per_rad))

--- a/stretch_calibration/nodes/process_head_calibration_data
+++ b/stretch_calibration/nodes/process_head_calibration_data
@@ -215,9 +215,8 @@ class HeadCalibrator:
         most_recent_filename = filenames[-1]
         self.head_calibration_data_filename = most_recent_filename
         print('Loading most recent head calibration data from a YAML file named ' + self.head_calibration_data_filename)
-        fid = open(self.head_calibration_data_filename, 'r')
-        self.data = yaml.load(fid)
-        fid.close()
+        with open(self.head_calibration_data_filename, 'r') as fid:
+            self.data = yaml.load(fid, Loader=yaml.FullLoader)
 
         # Convert data in yaml file from readable text to full joint
         # state representation and ROS Poses
@@ -773,9 +772,8 @@ class HeadCalibrator:
         urdf_string = self.new_urdf.to_xml_string()
         filename = self.calibration_directory + 'head_calibrated_' + time_string + '.urdf'
         print('Saving new URDF file to ', filename)
-        fid = open(filename, 'w')
-        fid.write(urdf_string)
-        fid.close()
+        with open(filename, 'w') as fid:
+            fid.write(urdf_string)
         print('Finished saving')
 
         
@@ -793,9 +791,8 @@ class HeadCalibrator:
 
         filename = self.calibration_directory + 'controller_calibration_head_' + time_string + '.yaml'
         print('Saving controller calibration head parameters to a YAML file named ', filename)
-        fid = open(filename, 'w')
-        yaml.dump(no_numpy_controller_parameters, fid)
-        fid.close()
+        with open(filename, 'w') as fid:
+            yaml.dump(no_numpy_controller_parameters, fid)
         print('Finished saving.')
 
         
@@ -848,9 +845,8 @@ class ProcessHeadCalibrationDataNode:
         # load default tilt backlash transition angle
         self.uncalibrated_controller_calibration_filename = rospy.get_param('~uncalibrated_controller_calibration_filename')
         rospy.loginfo('Loading factory default tilt backlash transition angle from the YAML file named {0}'.format(self.uncalibrated_controller_calibration_filename))
-        fid = open(self.uncalibrated_controller_calibration_filename, 'r')
-        default_controller_parameters = yaml.load(fid)
-        fid.close()
+        with open(self.uncalibrated_controller_calibration_filename, 'r') as fid:
+            default_controller_parameters = yaml.load(fid, Loader=yaml.FullLoader)
         tilt_angle_backlash_transition_rad = default_controller_parameters['tilt_angle_backlash_transition']
         deg_per_rad = 180.0/math.pi
         rospy.loginfo('self.tilt_angle_backlash_transition_rad in degrees = {0}'.format(tilt_angle_backlash_transition_rad * deg_per_rad))
@@ -867,9 +863,8 @@ class ProcessHeadCalibrationDataNode:
             else:
                 filename = self.opt_results_file_to_load
                 print('Loading CMA-ES result from a YAML file named ' + filename)
-            fid = open(filename, 'r')
-            cma_result = yaml.load(fid)
-            fid.close()
+            with open(filename, 'r') as fid:
+                cma_result = yaml.load(fid, Loader=yaml.FullLoader)
 
             show_data_used_during_optimization = True
             if show_data_used_during_optimization: 
@@ -1004,9 +999,8 @@ class ProcessHeadCalibrationDataNode:
                 print('********************************************************')
                 filename = self.calibration_directory + 'head_calibration_result_' + time_string + '.yaml'
                 print('Saving CMA-ES result to a YAML file named ', filename)
-                fid = open(filename, 'w')
-                yaml.dump(cma_result, fid)
-                fid.close()
+                with open(filename, 'w') as fid:
+                    yaml.dump(cma_result, fid)
                 print('Finished saving.')
 
                 fit_parameters = cma_result['best_parameters']

--- a/stretch_funmap/src/stretch_funmap/mapping.py
+++ b/stretch_funmap/src/stretch_funmap/mapping.py
@@ -472,18 +472,16 @@ class HeadScan:
                 'map_to_image_mat' : self.map_to_image_mat.tolist(), 
                 'map_to_base_mat' : self.map_to_base_mat.tolist()}
         
-        fid = open(base_filename + '.yaml', 'w')
-        yaml.dump(data, fid)
-        fid.close()
+        with open(base_filename + '.yaml', 'w') as fid:
+            yaml.dump(data, fid)
         print('Finished saving.')
 
         
     @classmethod
     def from_file(self, base_filename):
         print('HeadScan.from_file: base_filename =', base_filename)
-        fid = open(base_filename + '.yaml', 'r')
-        data = yaml.load(fid)
-        fid.close()
+        with open(base_filename + '.yaml', 'r') as fid:
+            data = yaml.load(fid, Loader=yaml.FullLoader)
 
         print('data =', data)
         max_height_image_base_filename = data['max_height_image_base_filename']

--- a/stretch_funmap/src/stretch_funmap/max_height_image.py
+++ b/stretch_funmap/src/stretch_funmap/max_height_image.py
@@ -400,9 +400,8 @@ class MaxHeightImage:
                 'transform_corrected_to_original': transform_corrected_to_original
         }
 
-        fid = open(base_filename + '.yaml', 'w')
-        yaml.dump(data, fid)
-        fid.close()
+        with open(base_filename + '.yaml', 'w') as fid:
+            yaml.dump(data, fid)
 
         print('Finished saving.')
 
@@ -410,9 +409,8 @@ class MaxHeightImage:
     @classmethod
     def load_serialization( self, base_filename ):
         print('MaxHeightImage: Loading serialization data from base_filename =', base_filename)
-        fid = open(base_filename + '.yaml', 'r')
-        data = yaml.load(fid)
-        fid.close()
+        with open(base_filename + '.yaml', 'r') as fid:
+            data = yaml.load(fid, Loader=yaml.FullLoader)
         
         image_filename = data['image_filename']
         fid = gzip.GzipFile(image_filename, 'r')


### PR DESCRIPTION
Closes #48. In addition to specifying the `Loader` attribute for `yaml.load`, I also change most instances of `fid = open(blah)` to `with open(blah) as fid`. With the former, if anyone in the future forgets to `fid.close()`, we have a memory leak.