### PR TITLE
Pluggable End Effectors - Melodic

### DIFF
--- a/hello_helpers/src/hello_helpers/simple_command_group.py
+++ b/hello_helpers/src/hello_helpers/simple_command_group.py
@@ -2,7 +2,7 @@ import hello_helpers.hello_misc as hm
 
 
 class SimpleCommandGroup:
-    def __init__(self, joint_name, joint_range, acceptable_joint_error=0.015):
+    def __init__(self, joint_name, joint_range, acceptable_joint_error=0.015, node=None):
         """Simple command group to extend
 
         Attributes
@@ -24,6 +24,8 @@ class SimpleCommandGroup:
         """
         self.name = joint_name
         self.range = joint_range
+        if self.range is None:
+            self.update_joint_range(None, node=node)
         self.active = False
         self.index = None
         self.goal = {"position": None}
@@ -42,6 +44,18 @@ class SimpleCommandGroup:
             return 1
 
         return 0
+
+    def update_joint_range(self, joint_range, node=None):
+        """Updates the commandable joint range
+
+        Parameters
+        ----------
+        joint_range: tuple(float, float) or None
+            updates range if provided, else calculates it automatically
+        node: StretchBodyNode or None
+            required to calculate range automatically
+        """
+        raise NotImplementedError
 
     def update(self, commanded_joint_names, invalid_joints_callback, **kwargs):
         """Activates joints in the group

--- a/stretch_core/nodes/command_groups.py
+++ b/stretch_core/nodes/command_groups.py
@@ -140,9 +140,9 @@ class WristYawCommandGroup(SimpleCommandGroup):
 
 class GripperCommandGroup(SimpleCommandGroup):
     def __init__(self, range_robotis=None, node=None):
+        self.gripper_conversion = GripperConversion()
         SimpleCommandGroup.__init__(self, 'joint_gripper_finger_left', range_robotis, acceptable_joint_error=1.0, node=node)
         self.gripper_joint_names = ['joint_gripper_finger_left', 'joint_gripper_finger_right', 'gripper_aperture']
-        self.gripper_conversion = GripperConversion()
         self.update_joint_range(range_robotis)
 
     def update_joint_range(self, joint_range, node=None):

--- a/stretch_core/nodes/joint_trajectory_server.py
+++ b/stretch_core/nodes/joint_trajectory_server.py
@@ -1,6 +1,8 @@
 #! /usr/bin/env python
 from __future__ import print_function
 
+import importlib
+
 import rospy
 import actionlib
 from control_msgs.msg import FollowJointTrajectoryAction

--- a/stretch_core/nodes/stretch_driver
+++ b/stretch_core/nodes/stretch_driver
@@ -150,13 +150,14 @@ class StretchBodyNode:
 
         # add gripper joints to joint state
         gripper_cg = self.joint_trajectory_action.gripper_cg
-        missing_gripper_joint_names = list(set([gripper_cg.gripper_joint_names]) - set(joint_state.name))
-        for j in missing_gripper_joint_names:
-            pos, vel, effort = gripper_cg.joint_state(robot_status, joint_name=j)
-            joint_state.name.append(j)
-            joint_state.position.append(pos)
-            joint_state.velocity.append(vel)
-            joint_state.effort.append(effort)
+        if gripper_cg is not None:
+            missing_gripper_joint_names = list(set([gripper_cg.gripper_joint_names]) - set(joint_state.name))
+            for j in missing_gripper_joint_names:
+                pos, vel, effort = gripper_cg.joint_state(robot_status, joint_name=j)
+                joint_state.name.append(j)
+                joint_state.position.append(pos)
+                joint_state.velocity.append(vel)
+                joint_state.effort.append(effort)
 
         self.joint_state_pub.publish(joint_state)
 

--- a/stretch_core/nodes/stretch_driver
+++ b/stretch_core/nodes/stretch_driver
@@ -277,11 +277,10 @@ class StretchBodyNode:
             self.robot.lift.move_by(0.0)
             self.robot.push_command()
 
-            self.robot.head.move_by('head_pan', 0.0)
-            self.robot.head.move_by('head_tilt', 0.0)
-            self.robot.end_of_arm.move_by('wrist_yaw', 0.0)
-            self.robot.end_of_arm.move_by('stretch_gripper', 0.0)
-            self.robot.push_command()
+            for joint in self.robot.head.joints:
+                self.robot.head.move_by(joint, 0.0)
+            for joint in self.robot.end_of_arm.joints:
+                self.robot.end_of_arm.move_by(joint, 0.0)
 
         rospy.loginfo('Received stop_the_robot service call, so commanded all actuators to stop.')
         return TriggerResponse(
@@ -321,11 +320,10 @@ class StretchBodyNode:
                 self.robot.lift.move_by(0.0)
                 self.robot.push_command()
 
-                self.robot.head.move_by('head_pan', 0.0)
-                self.robot.head.move_by('head_tilt', 0.0)
-                self.robot.end_of_arm.move_by('wrist_yaw', 0.0)
-                self.robot.end_of_arm.move_by('stretch_gripper', 0.0)
-                self.robot.push_command()
+                for joint in self.robot.head.joints:
+                    self.robot.head.move_by(joint, 0.0)
+                for joint in self.robot.end_of_arm.joints:
+                    self.robot.end_of_arm.move_by(joint, 0.0)
 
             self.robot.pimu.runstop_event_trigger()
         else:


### PR DESCRIPTION
This PR loads additional command groups as needed by reading the end effector configured in Stretch Body. For example, if the [Dex Wrist](https://hello-robot.com/stretch-dex-wrist) is attached to Stretch, additional command groups for the roll and pitch joints are added, allowing the joints to be commanded from joint trajectory action server and the joint states topic publishes state of the new joints as well.