### PR TITLE
Fix data shape for MaxHeightImage construction

### DIFF
--- a/stretch_funmap/src/stretch_funmap/max_height_image.py
+++ b/stretch_funmap/src/stretch_funmap/max_height_image.py
@@ -520,8 +520,8 @@ class MaxHeightImage:
             self.rgb_image = np.zeros(s[:2] + (3,), np.uint8)
 
         if self.camera_depth_image is None: 
-            nh.numba_max_height_and_rgb_images(points_to_image_mat, rgb_points, self.image, self.rgb_image, self.m_per_pix, self.m_per_height_unit, self.voi.x_in_m, self.voi.y_in_m, self.voi.z_in_m, verbose=False)
+            nh.numba_max_height_and_rgb_images(points_to_image_mat, rgb_points.ravel(), self.image, self.rgb_image, self.m_per_pix, self.m_per_height_unit, self.voi.x_in_m, self.voi.y_in_m, self.voi.z_in_m, verbose=False)
         else:
-            nh.numba_max_height_and_rgb_and_camera_depth_images(points_to_image_mat, rgb_points, self.image, self.rgb_image, self.camera_depth_image, self.m_per_pix, self.m_per_height_unit, self.voi.x_in_m, self.voi.y_in_m, self.voi.z_in_m, verbose=False)
+            nh.numba_max_height_and_rgb_and_camera_depth_images(points_to_image_mat, rgb_points.ravel(), self.image, self.rgb_image, self.camera_depth_image, self.m_per_pix, self.m_per_height_unit, self.voi.x_in_m, self.voi.y_in_m, self.voi.z_in_m, verbose=False)
 
 


### PR DESCRIPTION
I'm seeing crashes when doing anything with funmap in simulation:
 
 ```
 [ERROR] [1641864272.638119, 711.336000]: Error processing request: Failed in nopython mode pipeline (step: nopython frontend)
No implementation of function Function(<built-in function round>) found for signature:
 
 >>> round(array(float64, 1d, C))
 
There are 2 candidate implementations:
    - Of which 2 did not match due to:
    Type Restricted Function in function 'round': File: unknown: Line unknown.
      With argument(s): '(array(float64, 1d, C))':
     No match for registered cases:
      * (float32,) -> int64
      * (float64,) -> int64
      * (float32, int64) -> float32
      * (float64, int64) -> float64
During: resolving callee type: Function(<built-in function round>)
During: typing of call at /home/nick/workspaces/hello_ws/src/stretch_ros/stretch_funmap/src/stretch_funmap/numba_height_image.py (385)
File "../stretch_funmap/src/stretch_funmap/numba_height_image.py", line 385:
def numba_max_height_and_rgb_images_int(points_to_image_mat, rgb_points,
    <source elided>
        if (x > min_x) and (x < max_x) and (y > min_y) and (y < max_y) and (z > min_z) and (z < max_z):
            x_index = int(round(x / m_per_pix))
            ^
```

[ros_numpy will set the shape of the points buffer from a PCL message to the image dimensions (W,H)](https://github.com/eric-wieser/ros_numpy/blob/6758aa92210616c082d3fa63aedbc819d85e7744/src/ros_numpy/point_cloud2.py#L130), but this causes the underlying numba implementation to blow up when it tries to iterate over the points as though they were in a flat array:
https://github.com/hello-robot/stretch_ros/blob/b414df3db5d36df52f24ea97fd8d8682c2a045b0/stretch_funmap/src/stretch_funmap/numba_height_image.py#L443

 This patch ensures that a flat view of the data is passed through.
 
I'm not sure what would let others avoid this issue in the past. Maybe the real camera doesn't set the size fields on the message? It does not appear that this extra shape information is used by the rest of the code so the iteration would be the only place where differences would become apparent. 
 