### PR TITLE
Reduce robot/inflation radius for Stretch Navigation

### DIFF
--- a/stretch_navigation/config/common_costmap_params.yaml
+++ b/stretch_navigation/config/common_costmap_params.yaml
@@ -1,7 +1,7 @@
 obstacle_range: 2.5
 raytrace_range: 3.0
-robot_radius: 0.5
-inflation_radius: 0.55
+robot_radius: 0.2
+inflation_radius: 0.22
 
 observation_sources: laser_scan_sensor
 

--- a/stretch_navigation/config/global_costmap_params_nomap.yaml
+++ b/stretch_navigation/config/global_costmap_params_nomap.yaml
@@ -1,5 +1,5 @@
 global_costmap:
   global_frame: map
-  robot_base_frame: base_link
+  robot_base_frame: centered_base_link
   update_frequency: 5.0
   static_map: false

--- a/stretch_navigation/config/global_costmap_params_withmap.yaml
+++ b/stretch_navigation/config/global_costmap_params_withmap.yaml
@@ -1,5 +1,5 @@
 global_costmap:
   global_frame: map
-  robot_base_frame: base_link
+  robot_base_frame: centered_base_link
   update_frequency: 5.0
   static_map: true

--- a/stretch_navigation/config/local_costmap_params.yaml
+++ b/stretch_navigation/config/local_costmap_params.yaml
@@ -1,6 +1,6 @@
 local_costmap:
   global_frame: map
-  robot_base_frame: base_link
+  robot_base_frame: centered_base_link
   update_frequency: 5.0
   publish_frequency: 2.0
   static_map: false

--- a/stretch_navigation/launch/navigation.launch
+++ b/stretch_navigation/launch/navigation.launch
@@ -8,6 +8,9 @@
   <param name="/stretch_driver/mode" type="string" value="navigation" />
   <include file="$(find stretch_core)/launch/stretch_driver.launch" pass_all_args="true"/>
 
+  <!-- CENTERED BASE LINK -->
+  <node name="centered_base_link_tf_publisher" pkg="tf" type="static_transform_publisher" args="-0.1 0 0 0 0 0 1 /base_link /centered_base_link 100" />
+
   <!-- LASER RANGE FINDER -->
   <include file="$(find stretch_core)/launch/rplidar.launch" />
 


### PR DESCRIPTION
This PR refines the collision model to better represent the robot's footprint in the ROS Navigation Stack. The nav stack models the robot as a circle. Previously, this circle was centered at `base_link` and required a large radius to fit the robot's footprint within the model. Now, the circle is shifted back to the footprint's actual center, `centered_base_link`, and the radius is reduced to fit only the robot's footprint.