### PR TITLE
change robot name to stretch

### DIFF
--- a/stretch_description/urdf/stretch_description.xacro
+++ b/stretch_description/urdf/stretch_description.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="stretch_description">
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="stretch">
 
   <xacro:include filename="stretch_gripper.xacro" />
   <!--<xacro:include filename="stretch_gripper_with_puller.xacro" />-->

--- a/stretch_gazebo/urdf/stretch_gazebo.urdf.xacro
+++ b/stretch_gazebo/urdf/stretch_gazebo.urdf.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="stretch_description">
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="stretch">
   <xacro:arg name="gpu_lidar" default="false" />
   <xacro:arg name="visualize_lidar" default="false" />
 

--- a/stretch_moveit_config/config/stretch_description.srdf
+++ b/stretch_moveit_config/config/stretch_description.srdf
@@ -3,7 +3,7 @@
     This is a format for representing semantic information about the robot structure.
     A URDF file must exist for this robot as well, where the joints and the links that are referenced are defined
 -->
-<robot name="stretch_description">
+<robot name="stretch">
     <!--GROUPS: Representation of a set of joints and links. This can be useful for specifying DOF to plan for, defining arms, end effectors, etc-->
     <!--LINKS: When a link is specified, the parent joint of that link (if it exists) is automatically included-->
     <!--JOINTS: When a joint is specified, the child link of that joint (which will always exist) is automatically included-->


### PR DESCRIPTION
This PR change robot name from `stretch_description` to `stretch`.
`stretch_description` is the package name, not robot name.