### PR TITLE
Compile cython code during catkin build stretch_funmap 

### DIFF
--- a/stretch_funmap/CMakeLists.txt
+++ b/stretch_funmap/CMakeLists.txt
@@ -11,6 +11,14 @@ find_package(catkin REQUIRED COMPONENTS
   rospy
 )
 
+set(cython_code_dir ${CMAKE_CURRENT_SOURCE_DIR}/src/stretch_funmap)
+
+message("Compile cython code within cmake build")
+execute_process(
+  WORKING_DIRECTORY ${cython_code_dir}
+  COMMAND bash ${cython_code_dir}/compile_cython_code.sh
+)
+
 ## System dependencies are found with CMake's conventions
 # find_package(Boost REQUIRED COMPONENTS system)
 

--- a/stretch_funmap/package.xml
+++ b/stretch_funmap/package.xml
@@ -49,6 +49,7 @@
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>rospy</build_depend>
   <build_export_depend>rospy</build_export_depend>
+  <build_depend>cython3</build_depend>
   <exec_depend>rospy</exec_depend>
   <exec_depend>ros_numpy</exec_depend>
 

--- a/stretch_funmap/src/stretch_funmap/compile_cython_code.sh
+++ b/stretch_funmap/src/stretch_funmap/compile_cython_code.sh
@@ -1,8 +1,11 @@
 #!/bin/bash
 
 echo "Building cython_min_cost_path.pyx..."
-cython3 ./cython_min_cost_path.pyx 
-gcc -shared -pthread -fPIC -fwrapv -ffast-math -O3 -Wall -fno-strict-aliasing -I/usr/include/python3.8 -o cython_min_cost_path.so cython_min_cost_path.c
+cython3 ./cython_min_cost_path.pyx
+
+PY_INCLUDE_PATH=$(python -c 'from sysconfig import get_paths as gp; print(gp()["include"])')
+echo "Using python lib: $PY_INCLUDE_PATH"
+gcc -shared -pthread -fPIC -fwrapv -ffast-math -O3 -Wall -fno-strict-aliasing -I$PY_INCLUDE_PATH -o cython_min_cost_path.so cython_min_cost_path.c
 echo "Done."
 echo ""
 

--- a/stretch_funmap/src/stretch_funmap/compile_cython_code.sh
+++ b/stretch_funmap/src/stretch_funmap/compile_cython_code.sh
@@ -3,7 +3,7 @@
 echo "Building cython_min_cost_path.pyx..."
 cython3 ./cython_min_cost_path.pyx
 
-PY_INCLUDE_PATH=$(python -c 'from sysconfig import get_paths as gp; print(gp()["include"])')
+PY_INCLUDE_PATH=$(python3 -c 'from sysconfig import get_paths as gp; print(gp()["include"])')
 echo "Using python lib: $PY_INCLUDE_PATH"
 gcc -shared -pthread -fPIC -fwrapv -ffast-math -O3 -Wall -fno-strict-aliasing -I$PY_INCLUDE_PATH -o cython_min_cost_path.so cython_min_cost_path.c
 echo "Done."


### PR DESCRIPTION
## Environment
 - Ubunutu 22.04
 - ros noetic (install from source)
 - stretch_ros:  Install from source

## Issue
The `stretch_funmap.cython_min_cost_path` module is not available when building with the classic `catkin_make` approach. Other modules (e.g. manipulation_planning, mapping... ) are discoverable.

After looking into the `stretch_funmap` pkg, it seems that the `cython_min_cost_path` module is generated through `compile_cython_code.sh`. A recompilation of the ros pkg is needed after the cython compilation.

## Solution
To simplify the pipeline, the cython code is compiled within the catkin_make process. This can be achieved by executing the cython compilation script within the `CMakeLists`. The success of this custom process is optional, and will not block the compilation process.

Also, `PY_INCLUDE_PATH` var is used as the python lib path since the python version might vary on a different setups.