### PR TITLE
Command Group status effort_pct key fix

### DIFF
--- a/stretch_core/nodes/command_groups.py
+++ b/stretch_core/nodes/command_groups.py
@@ -370,7 +370,7 @@ class ArmCommandGroup(SimpleCommandGroup):
         arm_status = robot_status['arm']
         arm_backlash_correction = self.retracted_offset_m if self.retracted else 0.0
         pos = arm_status['pos'] + arm_backlash_correction
-        return (pos, arm_status['vel'], arm_status['motor']['effort'])
+        return (pos, arm_status['vel'], arm_status['motor']['effort_pct'])
 
 
 class LiftCommandGroup(SimpleCommandGroup):
@@ -410,7 +410,7 @@ class LiftCommandGroup(SimpleCommandGroup):
 
     def joint_state(self, robot_status, **kwargs):
         lift_status = robot_status['lift']
-        return (lift_status['pos'], lift_status['vel'], lift_status['motor']['effort'])
+        return (lift_status['pos'], lift_status['vel'], lift_status['motor']['effort_pct'])
 
 
 class MobileBaseCommandGroup(SimpleCommandGroup):


### PR DESCRIPTION
This PR changes the motor status key from 'effort' to 'effort_pct' in command groups, the only new supported unit system of stretch_ros with the new stretch_body 0.4.0. 