### PR TITLE
cv2 aruco api changes in detect_aruco_markers node

### DIFF
--- a/stretch_core/nodes/detect_aruco_markers
+++ b/stretch_core/nodes/detect_aruco_markers
@@ -511,8 +511,8 @@ class ArucoMarkerCollection:
         self.show_debug_images = show_debug_images
         
         self.marker_info = marker_info
-        self.aruco_dict = aruco.Dictionary_get(aruco.DICT_6X6_250)
-        self.aruco_detection_parameters =  aruco.DetectorParameters_create()
+        self.aruco_dict = aruco.getPredefinedDictionary(aruco.DICT_6X6_250)
+        self.aruco_detection_parameters = aruco.DetectorParameters()
         # Apparently available in OpenCV 3.4.1, but not OpenCV 3.2.0.
         self.aruco_detection_parameters.cornerRefinementMethod = aruco.CORNER_REFINE_SUBPIX
         self.aruco_detection_parameters.cornerRefinementWinSize = 2


### PR DESCRIPTION
This PR  fixes the API changes in the cv2.aruco library from Opencv python v4.7 and above in detect_aruco_marker node.