### PR TITLE
New joint_arm in stretch_driver action server

### DIFF
--- a/hello_helpers/README.md
+++ b/hello_helpers/README.md
@@ -69,16 +69,16 @@ self.move_to_pose({'joint_lift': 0.5})
 
 Internally, this dictionary is converted into a [FollowJointTrajectoryGoal](http://docs.ros.org/en/diamondback/api/control_msgs/html/msg/FollowJointTrajectoryGoal.html) that is sent to a [FollowJointTrajectory action](http://docs.ros.org/en/noetic/api/control_msgs/html/action/FollowJointTrajectory.html) server in stretch_driver. This method waits by default for the server to report that the goal has completed executing. However, you can return before the goal has completed by setting the `return_before_done` argument to True. This can be useful for preempting goals.
 
-There are two additional arguments that enable you to customize how the pose is executed. If you set `custom_contact_thresholds` to True, this method expects a different format dictionary: string/tuple key/value pairs, where the keys are still joint names, but the values are `(position_goal, effort_threshold)`. The addition of a effort threshold enables you to detect when a joint has made contact with something in the environment, which is useful for manipulation or safe movements. For example, `{'wrist_extension': (0.5, 20)}` commands the telescoping arm fully out (the arm is nearly fully extended at 0.5 meters) but with a low enough effort threshold (20% of the arm motor's max effort) that the motor will stop when the end of arm has made contact with something. Again, in a node, this would look like:
+There are two additional arguments that enable you to customize how the pose is executed. If you set `custom_contact_thresholds` to True, this method expects a different format dictionary: string/tuple key/value pairs, where the keys are still joint names, but the values are `(position_goal, effort_threshold)`. The addition of a effort threshold enables you to detect when a joint has made contact with something in the environment, which is useful for manipulation or safe movements. For example, `{'joint_arm': (0.5, 20)}` commands the telescoping arm fully out (the arm is nearly fully extended at 0.5 meters) but with a low enough effort threshold (20% of the arm motor's max effort) that the motor will stop when the end of arm has made contact with something. Again, in a node, this would look like:
 
 ```python
-self.move_to_pose({'wrist_extension': (0.5, 40)}, custom_contact_thresholds=True)
+self.move_to_pose({'joint_arm': (0.5, 40)}, custom_contact_thresholds=True)
 ```
 
 If you set `custom_full_goal` to True, the dictionary format is string/tuple key/value pairs, where keys are joint names again, but values are `(position_goal, velocity, acceleration, effort_threshold)`. The velocity and acceleration components allow you to customize the trajectory profile the joint follows while moving to the goal position. In the following example, the arm telescopes out slowly until contact is detected:
 
 ```python
-self.move_to_pose({'wrist_extension': (0.5, 0.01, 0.01, 40)}, custom_full_goal=True)
+self.move_to_pose({'joint_arm': (0.5, 0.01, 0.01, 40)}, custom_full_goal=True)
 ```
 
 ##### `get_robot_floor_pose_xya(floor_frame='odom')`

--- a/stretch_core/nodes/stretch_driver
+++ b/stretch_core/nodes/stretch_driver
@@ -189,7 +189,7 @@ class StretchDriverNode:
             joint_state.velocity.append(vel)
             joint_state.effort.append(effort)
 
-        # add telescoping joints to joint state
+        # add telescoping joints and wrist_extension to joint state
         arm_cg = self.joint_trajectory_action.arm_cg
         joint_state.name.extend(arm_cg.telescoping_joints)
         pos, vel, effort = arm_cg.joint_state(robot_status)
@@ -197,6 +197,10 @@ class StretchDriverNode:
             joint_state.position.append(pos / len(arm_cg.telescoping_joints))
             joint_state.velocity.append(vel / len(arm_cg.telescoping_joints))
             joint_state.effort.append(effort)
+        joint_state.name.append(arm_cg.wrist_extension_name)
+        joint_state.position.append(pos)
+        joint_state.velocity.append(vel)
+        joint_state.effort.append(effort)
 
         # add gripper joints to joint state
         gripper_cg = self.joint_trajectory_action.gripper_cg
@@ -452,8 +456,6 @@ class StretchDriverNode:
 
         self.linear_velocity_mps = 0.0 # m/s ROS SI standard for cmd_vel (REP 103)
         self.angular_velocity_radps = 0.0 # rad/s ROS SI standard for cmd_vel (REP 103)
-
-        self.max_arm_height = 1.1
 
         self.odom_pub = rospy.Publisher('odom', Odometry, queue_size=1)
 


### PR DESCRIPTION
This PR introduces "joint_arm" as a more easily understood name for the telescoping arm joint. When interacting with the FollowJointTrajectory action server from stretch_driver, you would previously use the name "wrist_extension" to send a command for the telescoping arm. Now, you can use either "joint_arm" or "wrist_extension". This allows any existing ROS program that calls "wrist_extension" to continue working, while new tutorials will refer to "joint_arm".

Additionally, this PR fixes a bug with stretch_driver's action server, where the feedback callback for an active telescoping command would error out due to an incorrectly formatted `named_error` value. Now, sending a telescoping command (e.g. joint_arm_l0 through l4) will not cause the node to error out.