### PR TITLE
Bugfix/dropped commands

### DIFF
--- a/stretch_core/nodes/command_groups.py
+++ b/stretch_core/nodes/command_groups.py
@@ -375,15 +375,16 @@ class ArmCommandGroup(SimpleCommandGroup):
             _, extension_error_m = self.update_execution(robot_status, force_single=True)
             self.retracted = extension_error_m < 0.0
             
-            if not self.goal_reached():
-                robot.arm.move_by(extension_error_m,
-                                  v_m=self.goal['velocity'],
-                                  a_m=self.goal['acceleration'],
-                                  contact_thresh_pos=self.goal['contact_threshold'],
-                                  contact_thresh_neg=-self.goal['contact_threshold'] \
-                                                       if self.goal['contact_threshold'] is not None else None)
-                return True
-            return False
+            
+            robot.arm.move_by(extension_error_m,
+                              v_m=self.goal['velocity'],
+                              a_m=self.goal['acceleration'],
+                              contact_thresh_pos=self.goal['contact_threshold'],
+                              contact_thresh_neg=-self.goal['contact_threshold'] \
+                                                   if self.goal['contact_threshold'] is not None else None)
+            
+            if self.goal_reached():
+                return False
         return True
 
     def update_execution(self, robot_status, **kwargs):
@@ -431,15 +432,14 @@ class LiftCommandGroup(SimpleCommandGroup):
     def init_execution(self, robot, robot_status, **kwargs):
         if self.active:
             _, lift_error_m = self.update_execution(robot_status)
-            if not self.goal_reached():
-                robot.lift.move_by(lift_error_m,
-                                   v_m=self.goal['velocity'],
-                                   a_m=self.goal['acceleration'],
-                                   contact_thresh_pos=self.goal['contact_threshold'],
-                                   contact_thresh_neg=-self.goal['contact_threshold'] \
-                                                        if self.goal['contact_threshold'] is not None else None)
-                return True
-            return False
+            robot.lift.move_by(lift_error_m,
+                               v_m=self.goal['velocity'],
+                               a_m=self.goal['acceleration'],
+                               contact_thresh_pos=self.goal['contact_threshold'],
+                               contact_thresh_neg=-self.goal['contact_threshold'] \
+                                                    if self.goal['contact_threshold'] is not None else None)
+            if self.goal_reached():
+                return False
         return True
 
     def update_execution(self, robot_status, **kwargs):

--- a/stretch_core/nodes/command_groups.py
+++ b/stretch_core/nodes/command_groups.py
@@ -34,10 +34,8 @@ class HeadPanCommandGroup(SimpleCommandGroup):
         if self.active:
             _, pan_error = self.update_execution(robot_status)
 
-            if not self.goal_reached():
-                robot.head.move_by('head_pan', pan_error, v_r=self.goal['velocity'], a_r=self.goal['acceleration'])
-                self.looked_left = pan_error > 0.0
-                return True
+            robot.head.move_by('head_pan', pan_error, v_r=self.goal['velocity'], a_r=self.goal['acceleration'])
+            self.looked_left = pan_error > 0.0
             return False
         return True
 
@@ -89,10 +87,8 @@ class HeadTiltCommandGroup(SimpleCommandGroup):
         if self.active:
             _, tilt_error = self.update_execution(robot_status)
 
-            if not self.goal_reached():
-                robot.head.move_by('head_tilt', tilt_error, v_r=self.goal['velocity'], a_r=self.goal['acceleration'])
-                self.looking_up = self.goal['position'] > (self.backlash_transition_angle_rad + self.calibrated_offset_rad)
-                return True
+            robot.head.move_by('head_tilt', tilt_error, v_r=self.goal['velocity'], a_r=self.goal['acceleration'])
+            self.looking_up = self.goal['position'] > (self.backlash_transition_angle_rad + self.calibrated_offset_rad)
             return False
         return True
 
@@ -134,12 +130,10 @@ class WristYawCommandGroup(SimpleCommandGroup):
         if self.active:
             _, wrist_yaw_error = self.update_execution(robot_status)
             
-            if not self.goal_reached():
-                robot.end_of_arm.move_by('wrist_yaw',
-                                         wrist_yaw_error,
-                                         v_r=self.goal['velocity'],
-                                         a_r=self.goal['acceleration'])
-                return True
+            robot.end_of_arm.move_by('wrist_yaw',
+                                     wrist_yaw_error,
+                                     v_r=self.goal['velocity'],
+                                     a_r=self.goal['acceleration'])
             return False
         return True
 
@@ -237,12 +231,10 @@ class GripperCommandGroup(SimpleCommandGroup):
             elif (self.name == 'joint_gripper_finger_left') or (self.name == 'joint_gripper_finger_right'):
                 gripper_robotis_error = self.gripper_conversion.finger_to_robotis(gripper_error)
             
-            if not self.goal_reached():
-                robot.end_of_arm.move_by('stretch_gripper',
-                                         gripper_robotis_error,
-                                         v_r=self.goal['velocity'],
-                                         a_r=self.goal['acceleration'])
-                return True
+            robot.end_of_arm.move_by('stretch_gripper',
+                                     gripper_robotis_error,
+                                     v_r=self.goal['velocity'],
+                                     a_r=self.goal['acceleration'])
             return False
         return True
 

--- a/stretch_core/nodes/command_groups.py
+++ b/stretch_core/nodes/command_groups.py
@@ -16,6 +16,7 @@ class HeadPanCommandGroup(SimpleCommandGroup):
             calibrated_looked_left_offset_rad = node.controller_parameters['pan_looked_left_offset']
         self.looked_left_offset_rad = calibrated_looked_left_offset_rad
         self.looked_left = False
+        
 
     def update_joint_range(self, joint_range, node=None):
         if joint_range is not None:
@@ -32,8 +33,13 @@ class HeadPanCommandGroup(SimpleCommandGroup):
     def init_execution(self, robot, robot_status, **kwargs):
         if self.active:
             _, pan_error = self.update_execution(robot_status)
-            robot.head.move_by('head_pan', pan_error, v_r=self.goal['velocity'], a_r=self.goal['acceleration'])
-            self.looked_left = pan_error > 0.0
+
+            if not self.goal_reached():
+                robot.head.move_by('head_pan', pan_error, v_r=self.goal['velocity'], a_r=self.goal['acceleration'])
+                self.looked_left = pan_error > 0.0
+                return True
+            return False
+        return True
 
     def update_execution(self, robot_status, **kwargs):
         self.error = None
@@ -65,6 +71,7 @@ class HeadTiltCommandGroup(SimpleCommandGroup):
             backlash_transition_angle_rad = node.controller_parameters['tilt_angle_backlash_transition']
         self.backlash_transition_angle_rad = backlash_transition_angle_rad
         self.looking_up = False
+        
 
     def update_joint_range(self, joint_range, node=None):
         if joint_range is not None:
@@ -81,8 +88,13 @@ class HeadTiltCommandGroup(SimpleCommandGroup):
     def init_execution(self, robot, robot_status, **kwargs):
         if self.active:
             _, tilt_error = self.update_execution(robot_status)
-            robot.head.move_by('head_tilt', tilt_error, v_r=self.goal['velocity'], a_r=self.goal['acceleration'])
-            self.looking_up = self.goal['position'] > (self.backlash_transition_angle_rad + self.calibrated_offset_rad)
+
+            if not self.goal_reached():
+                robot.head.move_by('head_tilt', tilt_error, v_r=self.goal['velocity'], a_r=self.goal['acceleration'])
+                self.looking_up = self.goal['position'] > (self.backlash_transition_angle_rad + self.calibrated_offset_rad)
+                return True
+            return False
+        return True
 
     def update_execution(self, robot_status, **kwargs):
         self.error = None
@@ -104,6 +116,7 @@ class HeadTiltCommandGroup(SimpleCommandGroup):
 class WristYawCommandGroup(SimpleCommandGroup):
     def __init__(self, range_rad=None, node=None):
         SimpleCommandGroup.__init__(self, 'joint_wrist_yaw', range_rad, node=node)
+         
 
     def update_joint_range(self, joint_range, node=None):
         if joint_range is not None:
@@ -119,10 +132,16 @@ class WristYawCommandGroup(SimpleCommandGroup):
 
     def init_execution(self, robot, robot_status, **kwargs):
         if self.active:
-            robot.end_of_arm.move_by('wrist_yaw',
-                                     self.update_execution(robot_status)[1],
-                                     v_r=self.goal['velocity'],
-                                     a_r=self.goal['acceleration'])
+            _, wrist_yaw_error_r = self.update_execution(robot_status)
+            
+            if not self.goal_reached():
+                robot.end_of_arm.move_by('wrist_yaw',
+                                         wrist_yaw_error,
+                                         v_r=self.goal['velocity'],
+                                         a_r=self.goal['acceleration'])
+                return True
+            return False
+        return True
 
     def update_execution(self, robot_status, **kwargs):
         self.error = None
@@ -143,6 +162,7 @@ class GripperCommandGroup(SimpleCommandGroup):
         SimpleCommandGroup.__init__(self, 'joint_gripper_finger_left', range_robotis, acceptable_joint_error=1.0, node=node)
         self.gripper_joint_names = ['joint_gripper_finger_left', 'joint_gripper_finger_right', 'gripper_aperture']
         self.update_joint_range(range_robotis)
+        
 
     def update_joint_range(self, joint_range, node=None):
         if joint_range is not None:
@@ -216,10 +236,15 @@ class GripperCommandGroup(SimpleCommandGroup):
                 gripper_robotis_error = self.gripper_conversion.aperture_to_robotis(gripper_error)
             elif (self.name == 'joint_gripper_finger_left') or (self.name == 'joint_gripper_finger_right'):
                 gripper_robotis_error = self.gripper_conversion.finger_to_robotis(gripper_error)
-            robot.end_of_arm.move_by('stretch_gripper',
-                                     gripper_robotis_error,
-                                     v_r=self.goal['velocity'],
-                                     a_r=self.goal['acceleration'])
+            
+            if not self.goal_reached():
+                robot.end_of_arm.move_by('stretch_gripper',
+                                         gripper_robotis_error,
+                                         v_r=self.goal['velocity'],
+                                         a_r=self.goal['acceleration'])
+                return True
+            return False
+        return True
 
     def update_execution(self, robot_status, **kwargs):
         self.error = None
@@ -356,13 +381,18 @@ class ArmCommandGroup(SimpleCommandGroup):
     def init_execution(self, robot, robot_status, **kwargs):
         if self.active:
             _, extension_error_m = self.update_execution(robot_status, force_single=True)
-            robot.arm.move_by(extension_error_m,
-                              v_m=self.goal['velocity'],
-                              a_m=self.goal['acceleration'],
-                              contact_thresh_pos=self.goal['contact_threshold'],
-                              contact_thresh_neg=-self.goal['contact_threshold'] \
-                                                   if self.goal['contact_threshold'] is not None else None)
             self.retracted = extension_error_m < 0.0
+            
+            if not self.goal_reached():
+                robot.arm.move_by(extension_error_m,
+                                  v_m=self.goal['velocity'],
+                                  a_m=self.goal['acceleration'],
+                                  contact_thresh_pos=self.goal['contact_threshold'],
+                                  contact_thresh_neg=-self.goal['contact_threshold'] \
+                                                       if self.goal['contact_threshold'] is not None else None)
+                return True
+            return False
+        return True
 
     def update_execution(self, robot_status, **kwargs):
         success_callback = kwargs['success_callback'] if 'success_callback' in kwargs.keys() else None
@@ -408,12 +438,17 @@ class LiftCommandGroup(SimpleCommandGroup):
 
     def init_execution(self, robot, robot_status, **kwargs):
         if self.active:
-            robot.lift.move_by(self.update_execution(robot_status)[1],
-                               v_m=self.goal['velocity'],
-                               a_m=self.goal['acceleration'],
-                               contact_thresh_pos=self.goal['contact_threshold'],
-                               contact_thresh_neg=-self.goal['contact_threshold'] \
-                                                    if self.goal['contact_threshold'] is not None else None)
+            _, lift_error_m = self.update_execution(robot_status)
+            if not self.goal_reached():
+                robot.lift.move_by(lift_error_m,
+                                   v_m=self.goal['velocity'],
+                                   a_m=self.goal['acceleration'],
+                                   contact_thresh_pos=self.goal['contact_threshold'],
+                                   contact_thresh_neg=-self.goal['contact_threshold'] \
+                                                        if self.goal['contact_threshold'] is not None else None)
+                return True
+            return False
+        return True
 
     def update_execution(self, robot_status, **kwargs):
         success_callback = kwargs['success_callback'] if 'success_callback' in kwargs.keys() else None
@@ -586,6 +621,7 @@ class MobileBaseCommandGroup(SimpleCommandGroup):
                                         v_m=self.goal['velocity'],
                                         a_m=self.goal['acceleration'],
                                         contact_thresh=self.goal['contact_threshold'])
+        return True
 
     def update_execution(self, robot_status, **kwargs):
         success_callback = kwargs['success_callback'] if 'success_callback' in kwargs.keys() else None

--- a/stretch_core/nodes/command_groups.py
+++ b/stretch_core/nodes/command_groups.py
@@ -613,6 +613,8 @@ class MobileBaseCommandGroup(SimpleCommandGroup):
                                         v_m=self.goal['velocity'],
                                         a_m=self.goal['acceleration'],
                                         contact_thresh=self.goal['contact_threshold'])
+            if self.goal_reached():
+                return False
         return True
 
     def update_execution(self, robot_status, **kwargs):

--- a/stretch_core/nodes/command_groups.py
+++ b/stretch_core/nodes/command_groups.py
@@ -58,7 +58,7 @@ class HeadPanCommandGroup(SimpleCommandGroup):
 
 class HeadTiltCommandGroup(SimpleCommandGroup):
     def __init__(self, range_rad=None, calibrated_offset_rad=None, calibrated_looking_up_offset_rad=None, backlash_transition_angle_rad=None, node=None):
-        SimpleCommandGroup.__init__(self, 'joint_head_tilt', range_rad, acceptable_joint_error=0.15, node=node)
+        SimpleCommandGroup.__init__(self, 'joint_head_tilt', range_rad, acceptable_joint_error=0.52, node=node)
         if calibrated_offset_rad is None:
             calibrated_offset_rad = node.controller_parameters['tilt_angle_offset']
         self.calibrated_offset_rad = calibrated_offset_rad

--- a/stretch_core/nodes/command_groups.py
+++ b/stretch_core/nodes/command_groups.py
@@ -60,7 +60,7 @@ class HeadPanCommandGroup(SimpleCommandGroup):
 
 class HeadTiltCommandGroup(SimpleCommandGroup):
     def __init__(self, range_rad=None, calibrated_offset_rad=None, calibrated_looking_up_offset_rad=None, backlash_transition_angle_rad=None, node=None):
-        SimpleCommandGroup.__init__(self, 'joint_head_tilt', range_rad, acceptable_joint_error=0.52, node=node)
+        SimpleCommandGroup.__init__(self, 'joint_head_tilt', range_rad, acceptable_joint_error=0.15, node=node)
         if calibrated_offset_rad is None:
             calibrated_offset_rad = node.controller_parameters['tilt_angle_offset']
         self.calibrated_offset_rad = calibrated_offset_rad

--- a/stretch_core/nodes/command_groups.py
+++ b/stretch_core/nodes/command_groups.py
@@ -132,7 +132,7 @@ class WristYawCommandGroup(SimpleCommandGroup):
 
     def init_execution(self, robot, robot_status, **kwargs):
         if self.active:
-            _, wrist_yaw_error_r = self.update_execution(robot_status)
+            _, wrist_yaw_error = self.update_execution(robot_status)
             
             if not self.goal_reached():
                 robot.end_of_arm.move_by('wrist_yaw',

--- a/stretch_core/nodes/joint_trajectory_server.py
+++ b/stretch_core/nodes/joint_trajectory_server.py
@@ -107,11 +107,11 @@ class JointTrajectoryAction:
 
             robot_status = self.node.robot.get_status() # uses lock held by robot
             
-            valid_movements = [c.init_execution(self.node.robot, robot_status) for c in self.command_groups]
-            nonvalid_movements_count = len(valid_movements) - sum(valid_movements)
+            movements_requiring_push = [c.init_execution(self.node.robot, robot_status) for c in self.command_groups]
+            movements_not_requiring_push_count = len(movements_requiring_push) - sum(movements_requiring_push)
             
             
-            if nonvalid_movements_count < len(commanded_joint_names):
+            if movements_not_requiring_push_count != len(commanded_joint_names):
             	self.node.robot.push_command()
 
             goals_reached = [c.goal_reached() for c in self.command_groups]

--- a/stretch_core/nodes/joint_trajectory_server.py
+++ b/stretch_core/nodes/joint_trajectory_server.py
@@ -107,18 +107,17 @@ class JointTrajectoryAction:
 
             robot_status = self.node.robot.get_status() # uses lock held by robot
             
-            successful_movements = [c.init_execution(self.node.robot, robot_status) for c in self.command_groups]
-            unsuccessful_movements_count = len(successful_movements) - sum(successful_movements)
+            valid_movements = [c.init_execution(self.node.robot, robot_status) for c in self.command_groups]
+            nonvalid_movements_count = len(valid_movements) - sum(valid_movements)
             
-            rospy.loginfo(("unsuccessful movements count: {0}\number of valid points: {1}").format(unsuccessful_movements_count, num_valid_points))
             
-            ## TODO find a count of commanded movements that is indepent of the amount of points in the trajectory goal
-            if unsuccessful_movements_count < num_valid_points:
+            if nonvalid_movements_count < len(commanded_joint_names):
             	self.node.robot.push_command()
 
             goals_reached = [c.goal_reached() for c in self.command_groups]
             update_rate = rospy.Rate(15.0)
             goal_start_time = rospy.Time.now()
+            
 
             while not all(goals_reached):
                 if (rospy.Time.now() - goal_start_time) > self.node.default_goal_timeout_duration:

--- a/stretch_core/nodes/joint_trajectory_server.py
+++ b/stretch_core/nodes/joint_trajectory_server.py
@@ -106,9 +106,15 @@ class JointTrajectoryAction:
                 return
 
             robot_status = self.node.robot.get_status() # uses lock held by robot
-            for c in self.command_groups:
-                c.init_execution(self.node.robot, robot_status)
-            self.node.robot.push_command()
+            
+            successful_movements = [c.init_execution(self.node.robot, robot_status) for c in self.command_groups]
+            unsuccessful_movements_count = len(successful_movements) - sum(successful_movements)
+            
+            rospy.loginfo(("unsuccessful movements count: {0}\number of valid points: {1}").format(unsuccessful_movements_count, num_valid_points))
+            
+            ## TODO find a count of commanded movements that is indepent of the amount of points in the trajectory goal
+            if unsuccessful_movements_count < num_valid_points:
+            	self.node.robot.push_command()
 
             goals_reached = [c.goal_reached() for c in self.command_groups]
             update_rate = rospy.Rate(15.0)


### PR DESCRIPTION
This fix addresses a bug that occurs when the `joint_trajectory_server` interprets a `FollowJointTrajectoryGoal` where all trajectory points are already within the `acceptable_joint_error` threshold and then within 1/80th of a second attempts to interpret another `FollowJointTrajectoryGoal`. The second call of `execute_cb()` calls the `robot.push_command()` method at a frequency higher then 80 hz resulting in a dropped motor command. This dropped motor command causes the `joint_trajectory_server` to find it's goals unreachable until the `default_goal_timeout_duration` of 10.0 seconds is reached.

In this fix the `init_execution()` method of each command group now returns a boolean value indicating if a subsequent call to `robot.push_command()` is appropriate. If at least one of commanded joints returns true (and thusly it can be inferred that joint will take time to move) `robot.push_command()` is called. The command groups controlling Dynamixel servos will always return false if active because they never require a `push_command()` call.

This bug can be recreated on the dev/noetic branch with this [gist](https://gist.github.com/hello-jackson/ae78a284f8d7d27e100105853a75ae7a) but not on the bugfix/dropped-commands branch.