### PR TITLE
Reduce err thres to prevent immediate goal success

### DIFF
--- a/stretch_core/nodes/command_groups.py
+++ b/stretch_core/nodes/command_groups.py
@@ -140,7 +140,7 @@ class WristYawCommandGroup(SimpleCommandGroup):
 class GripperCommandGroup(SimpleCommandGroup):
     def __init__(self, range_robotis=None, node=None):
         self.gripper_conversion = GripperConversion()
-        SimpleCommandGroup.__init__(self, 'joint_gripper_finger_left', range_robotis, acceptable_joint_error=1.0, node=node)
+        SimpleCommandGroup.__init__(self, 'joint_gripper_finger_left', range_robotis, acceptable_joint_error=0.015, node=node)
         self.gripper_joint_names = ['joint_gripper_finger_left', 'joint_gripper_finger_right', 'gripper_aperture']
         self.update_joint_range(range_robotis)
 


### PR DESCRIPTION
When the gripper joint is commanded through the trajectory server in position mode, the goal returns success immediately even before the goal is reached. This is because the error threshold, set at 1.0, is too high for when the gripper is commanded with the ‘gripper_finger_left/right’ joint names through the trajectory server.

E.g. joint_gripper_finger_left reports a position of 0 when fingers barely touch, and when fully open nominally returns 0.22. When the gripper is commanded to open from a zero position the error measurement (goal_pos - current_pos = 0.22 - 0) is already lower than the error threshold (0.22 < 1.0) which sets the goal as successful immediately.

Lowering the threshold to 0.015, the default for a [SimpleCommandGroup](https://github.com/hello-robot/stretch_ros/blob/noetic/hello_helpers/src/hello_helpers/simple_command_group.py#L5), prevents this behavior.
